### PR TITLE
Ensure raw user queries return integer user ids

### DIFF
--- a/segments/tests/test_helpers.py
+++ b/segments/tests/test_helpers.py
@@ -115,7 +115,7 @@ class TestSegmentHelper(TestCase):
         self.assertEquals(len(list(chunk_items([], len(members), 1))[0]), 0)
 
     def test_raw_user_query(self):
-        invalid = ['', None, 12345]
+        invalid = ['', None, 12345, "select 'pretendemail'"]
         for i in invalid:
             items, count = execute_raw_user_query(i)
             self.assertEquals(count, 0)


### PR DESCRIPTION
The execute_raw_user_query helper method is responsible for taking a user defined query and returning the results along with a count of their total.   These results are used to define segments.

Previously, the method was pretty flexible and assumed the query would return an integer corresponding to user ids.  In practice, sometimes less technical users would select on an email address, which could cause issues upstream.

This PR adds a guardrail that performs a loose type check to ensure the first parameter in the result set is an integer.  If not, it treats the query as though it produced an empty result and bounces it.