### PR TITLE
Fix `Segment`s being treated as falsey in certain situations

### DIFF
--- a/segments/models.py
+++ b/segments/models.py
@@ -95,6 +95,12 @@ class Segment(models.Model):
         """Calling len() on a segment returns the number of members of that segment."""
         return self.members_count
 
+    # A lot of code that interfaces with Django models expects model instances to be
+    # truthy, to distingiush them from `None`. Since we override `__len__`, `Segment`s
+    # with no members will be incorrectly treated as non-existent.
+    def __bool__(self):
+        return True
+
     def __str__(self):
         return self.name
 


### PR DESCRIPTION
`Segment`s with a 0 `member_count` return 0 from `__len__`, which makes python treat them as falsey. This can confuse libraries like `django_rest_framework` who treat falsey models as tantamount to `None` in a number of places. This overrides that behavior by provided an explicit `__bool__` conversion.