### PR TITLE
Check all values to be integer

### DIFF
--- a/segments/helpers.py
+++ b/segments/helpers.py
@@ -157,10 +157,10 @@ def execute_raw_user_query(sql):
         result = cursor.fetchall() or []
         total = len(result)
 
-        # Guardrail: Try to ensure results are integers
+        # Guardrail: Filter out None results
         if total > 0 and result[0]:
-            if not all(isinstance(i, int) for i in result[0]):
-                raise RuntimeError('Query returned non-integer results')
+            filtered_results = [i for i in result if i[0] is not None]
+            return [filtered_results, total]
 
         return [result, total]
 

--- a/segments/helpers.py
+++ b/segments/helpers.py
@@ -159,7 +159,7 @@ def execute_raw_user_query(sql):
 
         # Guardrail: Try to ensure results are integers
         if total > 0 and result[0]:
-            if not type(result[0][0]) == int:
+            if not all(isinstance(i, int) for i in result[0]):
                 raise RuntimeError('Query returned non-integer results')
 
         return [result, total]

--- a/segments/helpers.py
+++ b/segments/helpers.py
@@ -1,7 +1,6 @@
 import logging
 import redis
 
-from django.contrib.auth import get_user_model
 from django.db import connections
 from segments import app_settings
 
@@ -94,8 +93,8 @@ class SegmentHelper(object):
         del_key = 'del_s:%s:' % segment_id
 
         # Run the SQL query and store the latest set members
-        members, count = execute_raw_user_query(sql)
-        for id_block in chunk_items(members, count, 10000):
+        members = [m for m in execute_raw_user_query(sql) if m is not None]
+        for id_block in chunk_items(members, len(members), 10000):
             self.redis.sadd(add_key, *set(x[0] for x in id_block))
 
         # Store any new member adds
@@ -143,24 +142,18 @@ def chunk_items(items, length, chunk_size):
     for item in range(0, length, chunk_size):
         yield items[item:item + chunk_size]
 
+
 def execute_raw_user_query(sql):
     """
     Helper that returns an array containing a RawQuerySet of user ids and their total count.
     """
     if sql is None or not type(sql) == str or 'select' not in sql.lower():
-        return [[], 0]
+        return []
 
     with connections[app_settings.SEGMENTS_EXEC_CONNECTION].cursor() as cursor:
         # Fetch the raw queryset of ids and count them
         logger.info('SEGMENTS user query running: %s' % sql)
         cursor.execute(sql)
         result = cursor.fetchall() or []
-        total = len(result)
 
-        # Guardrail: Filter out None results
-        if total > 0 and result[0]:
-            filtered_results = [i for i in result if i[0] is not None]
-            return [filtered_results, total]
-
-        return [result, total]
-
+        return result

--- a/segments/models.py
+++ b/segments/models.py
@@ -104,6 +104,7 @@ class Segment(models.Model):
     def __str__(self):
         return self.name
 
+
 def do_refresh(sender, instance, created, **kwargs):
     """
     Connected to Segment's post_save signal.

--- a/segments/tests/test_helpers.py
+++ b/segments/tests/test_helpers.py
@@ -124,11 +124,9 @@ class TestSegmentHelper(TestCase):
             "SELECT * FROM ( VALUES (0), ('0'),) as foo;",
         ]
         for i in invalid:
-            items, count = execute_raw_user_query(i)
-            self.assertEquals(count, 0)
+            items = execute_raw_user_query(i)
             self.assertEquals(len(items), 0)
 
         valid_sql = 'select * from %s' % user_table()
-        items, count = execute_raw_user_query(valid_sql)
-        self.assertEquals(count, 1)
+        items = execute_raw_user_query(valid_sql)
         self.assertEquals(len(items), 1)

--- a/segments/tests/test_helpers.py
+++ b/segments/tests/test_helpers.py
@@ -115,7 +115,14 @@ class TestSegmentHelper(TestCase):
         self.assertEquals(len(list(chunk_items([], len(members), 1))[0]), 0)
 
     def test_raw_user_query(self):
-        invalid = ['', None, 12345, "select 'pretendemail'"]
+        invalid = [
+            '',
+            None,
+            12345,
+            "select 'pretendemail'",
+            "SELECT * FROM ( VALUES (0), (NULL),) as foo;",
+            "SELECT * FROM ( VALUES (0), ('0'),) as foo;",
+        ]
         for i in invalid:
             items, count = execute_raw_user_query(i)
             self.assertEquals(count, 0)


### PR DESCRIPTION
Bugfix. There are some cases when segment sql query returns NULL value. For now it raises exception if the NULL value comes first in the result set. This PR fixes that, and checks _every_ value to be integer. 
Actually I'm not sure why should we restrict the value to be an integer, since customer_id can be a UUID string as well (Not in our case, of course, just keeping in mind that it is open source repo and might be used by anybody). 