### PR TITLE
De 511 segment graceful fail

### DIFF
--- a/segments/helpers.py
+++ b/segments/helpers.py
@@ -85,13 +85,13 @@ class SegmentHelper(object):
         new_key = 'new_s:%s:' % segment_id
         del_key = 'del_s:%s:' % segment_id
 
-        # Run the SQL query and store the latest set members
-        self.run_pipeline(
-            iterable=(user_id for user_id in self.execute_raw_user_query(sql=sql) if user_id is not None),
-            operation=lambda pipeline, user_id: pipeline.sadd(add_key, user_id)
-        )
-
         try:
+            # Run the SQL query and store the latest set members
+            self.run_pipeline(
+                iterable=(user_id for user_id in self.execute_raw_user_query(sql=sql) if user_id is not None),
+                operation=lambda pipeline, user_id: pipeline.sadd(add_key, user_id)
+            )
+
             # Store any new member adds
             self.redis.sdiffstore(
                 dest=new_key,

--- a/segments/models.py
+++ b/segments/models.py
@@ -51,10 +51,7 @@ class Segment(models.Model):
     priority = models.PositiveIntegerField(null=True, blank=True)
     members_count = models.PositiveIntegerField(null=True, blank=True, default=0)
     created_date = models.DateTimeField(auto_now_add=True)
-    # can make updated_date false and have it update only for certain fields manually OR https://stackoverflow.com/questions/7499767/temporarily-disable-auto-now-auto-now-add temporary hack
-    # but we should stick to auto_now for updated_date since that should have the last time of modified date
-    # another way to track failure is create segment log table to dump all logs to or datadog or create status/enums to check if it failed
-    updated_date = models.DateTimeField(null=True, blank=True, db_index=True, auto_now=True) 
+    updated_date = models.DateTimeField(null=True, blank=True, db_index=True, auto_now=True)
     recalculated_date = models.DateTimeField(null=True, blank=True)
 
     helper = SegmentHelper()
@@ -79,8 +76,6 @@ class Segment(models.Model):
 
     @live_sql
     def refresh(self):
-        # still need to track if it failed
-        # Segment.objects.select_for_update().filter(id=self.id).update(recalculated_date=timezone.now())
         members_count = self.helper.refresh_segment(self.id, self.definition)
         Segment.objects.select_for_update().filter(id=self.id).update(members_count=members_count, recalculated_date=timezone.now())
         self.refresh_from_db()

--- a/segments/models.py
+++ b/segments/models.py
@@ -51,7 +51,10 @@ class Segment(models.Model):
     priority = models.PositiveIntegerField(null=True, blank=True)
     members_count = models.PositiveIntegerField(null=True, blank=True, default=0)
     created_date = models.DateTimeField(auto_now_add=True)
-    updated_date = models.DateTimeField(null=True, blank=True, db_index=True, auto_now=True)
+    # can make updated_date false and have it update only for certain fields manually OR https://stackoverflow.com/questions/7499767/temporarily-disable-auto-now-auto-now-add temporary hack
+    # but we should stick to auto_now for updated_date since that should have the last time of modified date
+    # another way to track failure is create segment log table to dump all logs to or datadog or create status/enums to check if it failed
+    updated_date = models.DateTimeField(null=True, blank=True, db_index=True, auto_now=True) 
     recalculated_date = models.DateTimeField(null=True, blank=True)
 
     helper = SegmentHelper()
@@ -76,6 +79,8 @@ class Segment(models.Model):
 
     @live_sql
     def refresh(self):
+        # still need to track if it failed
+        # Segment.objects.select_for_update().filter(id=self.id).update(recalculated_date=timezone.now())
         members_count = self.helper.refresh_segment(self.id, self.definition)
         Segment.objects.select_for_update().filter(id=self.id).update(members_count=members_count, recalculated_date=timezone.now())
         self.refresh_from_db()

--- a/segments/tests/test_helpers.py
+++ b/segments/tests/test_helpers.py
@@ -65,9 +65,11 @@ class TestSegmentHelper(TestCase):
         self.helper.remove_refreshed_user(self.user.id)
         self.assertEquals(len(list(self.helper.get_refreshed_users())), 0)
 
-    def test_refresh_segment_invalid_sql(self):
+    @patch('segments.helpers.logger')
+    def test_refresh_segment_invalid_sql(self, mock_logger):
         invalid_sql = 'abc select '
-        self.assertRaises(OperationalError, self.helper.refresh_segment, self.segment.id, invalid_sql)
+        self.assertEquals(self.helper.refresh_segment(self.segment.id, invalid_sql), 0)
+        mock_logger.exception.assert_called_with('SEGMENTS: refresh_segment(1, abc select ): near "abc": syntax error')
 
     def test_refresh_segment_valid_sql(self):
         valid_sql = 'select * from %s' % user_table()


### PR DESCRIPTION
this is to address https://groveco.atlassian.net/browse/DE-511 issue 
so overview:

provide logging exception to know what failed in refresh_segment
add try catch finally so that we can delete redis, cleanup sets, and add expiration even with fail

by doing so a)we fail gracefully and clean up intermediary keys, refreshed_at will be updated as it gets caught 

its good to keep in mind how much of an impact this could have considering now we clean up keys so even with failure, we need to make sure we are aware of the side effects. I can also have it reraise exception, to be safe