### PR TITLE
Remove emission of row in case it has PII

### DIFF
--- a/segments/helpers.py
+++ b/segments/helpers.py
@@ -249,4 +249,4 @@ class SegmentHelper(object):
                     if self.is_valid_member_id(row[0]):
                         yield row[0]
                     else:
-                        logger.exception(f"Query returned invalid result: {row[0]}")
+                        logger.error(f"Invalid result for sql query:\n{sql}", stack_info=True, exc_info=True)


### PR DESCRIPTION
## Description
A recent Sentry error was caused by a look's sql throwing an exception when the sql query returned customer email addresses, which is sensitive information. This change raises an exception around the sql that was produced, rather than the result of that sql.