### PR TITLE
Updated deprecated InvalidQuery Class 

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -45,7 +45,7 @@ Installation
 ------------
 To use, first install (pypi package coming soon)::
 
-    pip install -e git+https://github.com/groveco/django-segments#egg=segments
+    pip install -e git+https://github.com/groveco/django-segments#egg=django-segments
 
 Then add the following to your settings.py::
 

--- a/segments/helpers.py
+++ b/segments/helpers.py
@@ -2,7 +2,7 @@ import logging
 import redis
 
 from django.db import connections
-from django.db.models.query_utils import InvalidQuery
+from django.core.exceptions import FieldDoesNotExist
 
 from segments import app_settings
 
@@ -233,7 +233,7 @@ class SegmentHelper(object):
         Helper that returns an array containing a RawQuerySet of user ids and their total count.
         """
         if sql is None or not isinstance(sql, str) or "select" not in sql.lower():
-            raise InvalidQuery
+            raise FieldDoesNotExist
 
         with connections[app_settings.SEGMENTS_EXEC_CONNECTION].cursor() as cursor:
             # Fetch the raw queryset of ids and count them

--- a/segments/models.py
+++ b/segments/models.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.db import models, DatabaseError, OperationalError
-from django.db.models.query_utils import InvalidQuery
+from django.core.exceptions import FieldDoesNotExist
 from django.conf import settings
 from django.db.models import signals
 from django.utils import timezone
@@ -27,7 +27,7 @@ def live_sql(fn):
         try:
             return fn(*args, **kwargs)
 
-        except InvalidQuery:
+        except FieldDoesNotExist:
             raise SegmentExecutionError(
                 "SQL definition must include the primary key of the %s model"
                 % settings.AUTH_USER_MODEL


### PR DESCRIPTION
InvalidQuery class is remove from django 4.0
Use FieldDoesNotExist class instead