### PR TITLE
Fixed strings in migrations

### DIFF
--- a/segments/migrations/0002_auto_20151028_1326.py
+++ b/segments/migrations/0002_auto_20151028_1326.py
@@ -14,11 +14,11 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='segment',
             name='static_ids',
-            field=models.TextField(help_text=b'Newline delimited list of static IDs to hold in the segment', null=True, blank=True),
+            field=models.TextField(help_text='Newline delimited list of static IDs to hold in the segment', null=True, blank=True),
         ),
         migrations.AlterField(
             model_name='segment',
             name='definition',
-            field=models.TextField(help_text=b'SQL query that returns IDs of users in the segment.', null=True, blank=True),
+            field=models.TextField(help_text='SQL query that returns IDs of users in the segment.', null=True, blank=True),
         ),
     ]

--- a/segments/migrations/0003_auto_20151028_1914.py
+++ b/segments/migrations/0003_auto_20151028_1914.py
@@ -19,11 +19,11 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='segment',
             name='definition',
-            field=models.TextField(help_text=b'SQL query returning IDs of users in the segment.', null=True, blank=True),
+            field=models.TextField(help_text='SQL query returning IDs of users in the segment.', null=True, blank=True),
         ),
         migrations.AlterField(
             model_name='segment',
             name='static_ids',
-            field=models.TextField(help_text=b'Newline-delimited list of IDs in the segment', null=True, blank=True),
+            field=models.TextField(help_text='Newline-delimited list of IDs in the segment', null=True, blank=True),
         ),
     ]

--- a/segments/migrations/0004_auto_20170427_1423.py
+++ b/segments/migrations/0004_auto_20170427_1423.py
@@ -16,14 +16,14 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='segment',
             name='manager_method',
-            field=models.CharField(blank=True, help_text=b'Methoed to call on ContentType.model_class().manager_name',
+            field=models.CharField(blank=True, help_text='Methoed to call on ContentType.model_class().manager_name',
                                    max_length=128, null=True),
         ),
         migrations.AddField(
             model_name='segment',
             name='manager_name',
             field=models.CharField(default=b'objects',
-                                   help_text=b"If using manager_method, specify the name of the manager (usually 'objects')",
+                                   help_text="If using manager_method, specify the name of the manager (usually 'objects')",
                                    max_length=128),
         ),
     ]


### PR DESCRIPTION
Fixed strings in migrations, so `makemigrations` does not produce a migration to change the strings