### PR TITLE
updating django package.

### DIFF
--- a/segments/helpers.py
+++ b/segments/helpers.py
@@ -2,7 +2,7 @@ import logging
 import redis
 
 from django.db import connections
-from django.db.models.query_utils import InvalidQuery
+from django.core.exceptions import FieldError
 
 from segments import app_settings
 
@@ -247,7 +247,7 @@ class SegmentHelper(object):
         Helper that returns an array containing a RawQuerySet of user ids and their total count.
         """
         if sql is None or not isinstance(sql, str) or "select" not in sql.lower():
-            raise InvalidQuery
+            raise FieldError
 
         with connections[app_settings.SEGMENTS_EXEC_CONNECTION].cursor() as cursor:
             # Fetch the raw queryset of ids and count them

--- a/segments/models.py
+++ b/segments/models.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.db import models, DatabaseError, OperationalError
-from django.db.models.query_utils import InvalidQuery
+from django.core.exceptions import FieldError
 from django.conf import settings
 from django.db.models import signals
 from django.utils import timezone
@@ -27,7 +27,7 @@ def live_sql(fn):
         try:
             return fn(*args, **kwargs)
 
-        except InvalidQuery:
+        except FieldError:
             raise SegmentExecutionError(
                 "SQL definition must include the primary key of the %s model"
                 % settings.AUTH_USER_MODEL

--- a/segments/tests/test_helpers.py
+++ b/segments/tests/test_helpers.py
@@ -1,5 +1,5 @@
 import fakeredis
-from django.db.models.query_utils import InvalidQuery
+from django.core.exceptions import FieldError
 from django.db.utils import OperationalError
 from django.test import TestCase
 
@@ -96,7 +96,7 @@ class TestExecuteQuery(TestCase):
     def test_invalid_raw_user_query_raises_exception(self):
         empty_queries = ["", None, 1, True, "any string that does not contain s.elect"]
         for query in empty_queries:
-            with self.assertRaises(InvalidQuery, msg=f'Passed query: "{query}"') as cm:
+            with self.assertRaises(FieldError, msg=f'Passed query: "{query}"') as cm:
                 generator = self.helper.execute_raw_user_query(query)
                 for _ in generator:
                     pass


### PR DESCRIPTION
InvalidQuery has been deprecated: https://docs.djangoproject.com/en/5.0/releases/4.0/#features-removed-in-4-0

fielderror is used to raise exception when there is an issue with the model. https://docs.djangoproject.com/en/5.0/ref/exceptions/#fielderror
